### PR TITLE
Add License field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     ]
   },
   "repository": "https://github.com/atom/autoflow",
+  "license": "MIT",
   "engines": {
     "atom": "*"
   }


### PR DESCRIPTION
Add license field to `package.json` per https://github.com/atom/atom/pull/6645. :page_facing_up: 