### PR TITLE
Support for the Russian letters

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -54,7 +54,7 @@ module.exports =
     atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
 
   wrapSegment: (segment, currentLineLength, wrapColumn) ->
-    /\w/.test(segment) and
+    /[\wа-яё]/i.test(segment) and
       (currentLineLength + segment.length > wrapColumn) and
       (currentLineLength > 0 or segment.length < wrapColumn)
 

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -54,7 +54,7 @@ module.exports =
     atom.config.get('editor.preferredLineLength', scope: editor.getRootScopeDescriptor())
 
   wrapSegment: (segment, currentLineLength, wrapColumn) ->
-    /[\wа-яё]/i.test(segment) and
+    /[\w\u0410-\u042F\u0401\u0430-\u044F\u0451]/.test(segment) and
       (currentLineLength + segment.length > wrapColumn) and
       (currentLineLength > 0 or segment.length < wrapColumn)
 

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -245,3 +245,14 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'handles `yo` character properly', -> # Because there're known problems with this character in major regex engines
+      text = 'Ё Ё Ё'
+
+      res = '''
+        Ё
+        Ё
+        Ё
+      '''
+
+      expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -232,3 +232,16 @@ describe "Autoflow package", ->
         ea nulla ut commodo minim consequat cillum ad velit quis.
       '''
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'handles cyrillic text', ->
+      text = '''
+        В начале июля, в чрезвычайно жаркое время, под вечер, один молодой человек вышел из своей каморки, которую нанимал от жильцов в С-м переулке, на улицу и медленно, как бы в нерешимости, отправился к К-ну мосту.
+      '''
+
+      res = '''
+        В начале июля, в чрезвычайно жаркое время, под вечер, один молодой человек вышел
+        из своей каморки, которую нанимал от жильцов в С-м переулке, на улицу и
+        медленно, как бы в нерешимости, отправился к К-ну мосту.
+      '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res


### PR DESCRIPTION
Added the tests and fixed the implementation to work with Russian letters.

I haven't find the best way to encode proper `\w` in node.js regex, so I've decided to simply hardcode the alphabet in the way all Russian coders used to. Maybe we'll have to find a solution better than regexp.

(Test code contains an excerpt from Dostoyevsky's [Crime and Punishment](https://en.wikipedia.org/wiki/Crime_and_Punishment) if you're interested.)

This fix will close #28.