### PR TITLE
Correctly reflow text with CRLF line endings

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -17,6 +17,9 @@ module.exports =
 
   reflow: (text, {wrapColumn}) ->
     paragraphs = []
+    # Convert all \r\n and \r to \n. The text buffer will normalize them later
+    text = text.replace(/\r\n/g, '\n')
+    text = text.replace(/\r/g, '\n')
     paragraphBlocks = text.split(/\n\s*\n/g)
 
     for block in paragraphBlocks

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -232,3 +232,16 @@ describe "Autoflow package", ->
         ea nulla ut commodo minim consequat cillum ad velit quis.
       '''
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly handles CRLF', ->
+      text = "This is the first line and it is longer than the preferred line length so it should be reflowed.\r\nThis is a short line which should\r\nbe reflowed with the following line.\r\nAnother long line, it should also be reflowed with everything above it when it is all reflowed."
+
+      res =
+        '''
+        This is the first line and it is longer than the preferred line length so it
+        should be reflowed. This is a short line which should be reflowed with the
+        following line. Another long line, it should also be reflowed with everything
+        above it when it is all reflowed.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res


### PR DESCRIPTION
Currently only the \n component of a line ending is removed when
reflowing text with \r\n line endings. This change replaces all
instances of \r\n and \r with \n, which is reflowed correctly.
The text buffer will normalize the line endings afterwards.

Closes #17