### PR TITLE
Treat '%' as a comment character

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -22,7 +22,7 @@ module.exports =
     for block in paragraphBlocks
 
       # TODO: this could be more language specific. Use the actual comment char.
-      linePrefix = block.match(/^\s*[\/#*-]*\s*/g)[0]
+      linePrefix = block.match(/^\s*[\/#*%-]*\s*/g)[0]
       blockLines = block.split('\n')
 
       if linePrefix


### PR DESCRIPTION
A line beginning with '%' is a single line comment in: Erlang, Prolog,
LaTeX, MATLAB and PostScript.
