### PR TITLE
Handle newlines at beginning and end of selection.

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -28,6 +28,19 @@ module.exports =
     paragraphs = []
     # Convert all \r\n and \r to \n. The text buffer will normalize them later
     text = text.replace(/\r\n?/g, '\n')
+
+    leadingVerticalSpace = text.match(/^\s*\n/)
+    if leadingVerticalSpace
+      text = text.substr(leadingVerticalSpace.length)
+    else
+      leadingVerticalSpace = ''
+
+    trailingVerticalSpace = text.match(/\n\s*$/)
+    if trailingVerticalSpace
+      text = text.substr(0, text.length - trailingVerticalSpace.length)
+    else
+      trailingVerticalSpace = ''
+
     paragraphBlocks = text.split(/\n\s*\n/g)
     if tabLength
       tabLengthInSpaces = Array(tabLength + 1).join(' ')
@@ -66,7 +79,7 @@ module.exports =
 
       paragraphs.push(lines.join('\n').replace(/\s+\n/g, '\n'))
 
-    paragraphs.join('\n\n')
+    leadingVerticalSpace + paragraphs.join('\n\n') + trailingVerticalSpace
 
   getTabLength: (editor) ->
     atom.config.get('editor.tabLength', scope: editor.getRootScopeDescriptor()) ? 2

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -69,6 +69,37 @@ describe "Autoflow package", ->
         command.
       """
 
+    it "is not confused when the selection boundary is between paragraphs", ->
+      editor.setText """
+        v--- SELECTION STARTS AT THE BEGINNING OF THE NEXT LINE (pos 1,0)
+
+        The preceding newline should not be considered part of this paragraph.
+
+        The newline at the end of this paragraph should be preserved and not
+        converted into a space.
+
+        ^--- SELECTION ENDS AT THE BEGINNING OF THE PREVIOUS LINE (pos 6,0)
+      """
+
+      editor.setCursorBufferPosition([1, 0])
+      editor.selectToBufferPosition([6, 0])
+      atom.commands.dispatch editorElement, 'autoflow:reflow-selection'
+
+      expect(editor.getText()).toBe """
+        v--- SELECTION STARTS AT THE BEGINNING OF THE NEXT LINE (pos 1,0)
+
+        The preceding newline should
+        not be considered part of this
+        paragraph.
+
+        The newline at the end of this
+        paragraph should be preserved
+        and not converted into a
+        space.
+
+        ^--- SELECTION ENDS AT THE BEGINNING OF THE PREVIOUS LINE (pos 6,0)
+      """
+
     it "reflows the current paragraph if nothing is selected", ->
       editor.setText """
         This is a preceding paragraph, which shouldn't be modified by a reflow of the following paragraph.


### PR DESCRIPTION
This commit fixes a bug in `reflow` when the selection begins on the line before the start of a paragraph, or ends on the line immediately after the paragraph. In that case, a space was being inserted at the start of the initial paragraph's first line, and at the end of the final paragraph's last line. Additionally, the blank line after the final paragraph was being lost.

Here are two screenshots that illustrate the problem.  The first shows the extent of the selection before the reflow:

![atom_autoflow_boundary_bug_1](https://cloud.githubusercontent.com/assets/959/11092742/2d54d282-884b-11e5-9820-85390e1c56e2.png)

The second shows the situation after the reflow:

![atom_autoflow_boundary_bug_2](https://cloud.githubusercontent.com/assets/959/11092751/38b14ade-884b-11e5-90f2-de3cb4d72985.png)

Note that after reflow the first flowed paragraph starts with a leading space, and also that the last flowed paragraph ends with a trailing space, and the blank line following it is gone.  (The trailing-spaces package is active so that you can see the trailing space.)

This pull request fixes the problem.