### PR TITLE
Fix up the reflow behavior of MD lists, a bunch of comment styles, and ascii email inclusions

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -50,7 +50,7 @@ module.exports =
     for block in paragraphBlocks
 
       # TODO: this could be more language specific. Use the actual comment char.
-      linePrefix = block.match(/^\s*[\/#*%->(;;)]*\s*/g)[0]
+      linePrefix = block.match(/^\s*[\/#*%->(;;)(#')']*\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)
@@ -68,22 +68,22 @@ module.exports =
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length
 
-      notFirstLine = false;
+      notFirstLine = false
       for segment in @segmentText(blockLines.join(' '))
         if @wrapSegment(segment, currentLineLength, wrapColumn)
 
           # Independent of line prefix don't mess with it on the first line
           if notFirstLine
             # Handle C comments
-            if linePrefix.search(/^\s*\/\*/) != -1
+            if linePrefix.search(/^\s*\/\*/) isnt -1
               linePrefix = linePrefix.replace(/^(\s*)\/\*/, '$1  ')
             # Handle - list items
-            else if linePrefix.search(/^\s*-/) != -1
+            else if linePrefix.search(/^\s*-/) isnt -1
               linePrefix = linePrefix.replace(/^(\s*)[\/#*-]/, '$1 ')
           lines.push(linePrefix + currentLine.join(''))
           currentLine = []
           currentLineLength = linePrefixTabExpanded.length
-          notFirstLine = true;
+          notFirstLine = true
         currentLine.push(segment)
         currentLineLength += segment.length
       lines.push(linePrefix + currentLine.join(''))

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -68,12 +68,12 @@ module.exports =
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length
 
-      notFirstLine = false
+      firstLine = true
       for segment in @segmentText(blockLines.join(' '))
         if @wrapSegment(segment, currentLineLength, wrapColumn)
 
           # Independent of line prefix don't mess with it on the first line
-          if notFirstLine
+          if firstLine isnt true
             # Handle C comments
             if linePrefix.search(/^\s*\/\*/) isnt -1
               linePrefix = linePrefix.replace(/^(\s*)\/\*/, '$1  ')
@@ -83,7 +83,7 @@ module.exports =
           lines.push(linePrefix + currentLine.join(''))
           currentLine = []
           currentLineLength = linePrefixTabExpanded.length
-          notFirstLine = true
+          firstLine = false
         currentLine.push(segment)
         currentLineLength += segment.length
       lines.push(linePrefix + currentLine.join(''))

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -68,6 +68,10 @@ module.exports =
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length
 
+      wrappedLinePrefix = linePrefix
+        .replace(/^(\s*)\/\*/, '$1  ')
+        .replace(/^(\s*)-/, '$1 ')
+
       firstLine = true
       for segment in @segmentText(blockLines.join(' '))
         if @wrapSegment(segment, currentLineLength, wrapColumn)
@@ -75,11 +79,8 @@ module.exports =
           # Independent of line prefix don't mess with it on the first line
           if firstLine isnt true
             # Handle C comments
-            if linePrefix.search(/^\s*\/\*/) isnt -1
-              linePrefix = linePrefix.replace(/^(\s*)\/\*/, '$1  ')
-            # Handle - list items
-            else if linePrefix.search(/^\s*-/) isnt -1
-              linePrefix = linePrefix.replace(/^(\s*)[\/#*-]/, '$1 ')
+            if linePrefix.search(/^\s*\/\*/) isnt -1 or linePrefix.search(/^\s*-/) isnt -1
+              linePrefix = wrappedLinePrefix
           lines.push(linePrefix + currentLine.join(''))
           currentLine = []
           currentLineLength = linePrefixTabExpanded.length

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -50,7 +50,7 @@ module.exports =
     for block in paragraphBlocks
 
       # TODO: this could be more language specific. Use the actual comment char.
-      linePrefix = block.match(/^\s*[\/#*-]*\s*/g)[0]
+      linePrefix = block.match(/^\s*[\/#*%->(;;)]*\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)
@@ -68,11 +68,22 @@ module.exports =
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length
 
+      notFirstLine = false;
       for segment in @segmentText(blockLines.join(' '))
         if @wrapSegment(segment, currentLineLength, wrapColumn)
+
+          # Independent of line prefix don't mess with it on the first line
+          if notFirstLine
+            # Handle C comments
+            if linePrefix.search(/^\s*\/\*/) != -1
+              linePrefix = linePrefix.replace(/^(\s*)\/\*/, '$1  ')
+            # Handle - list items
+            else if linePrefix.search(/^\s*-/) != -1
+              linePrefix = linePrefix.replace(/^(\s*)[\/#*-]/, '$1 ')
           lines.push(linePrefix + currentLine.join(''))
           currentLine = []
           currentLineLength = linePrefixTabExpanded.length
+          notFirstLine = true;
         currentLine.push(segment)
         currentLineLength += segment.length
       lines.push(linePrefix + currentLine.join(''))

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -311,3 +311,145 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
+
+    it 'properly reflows // comments ', ->
+      # Because there're known problems with this character in major regex engines
+      text =
+        '''
+        // Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        // Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard
+        // sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        // fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest
+        // quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro
+        // actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia
+        // sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher
+        // direct trade, tacos pickled fanny pack literally meh pinterest slow-carb.
+        // Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows /* comments ', ->
+      # Because there're known problems with this character in major regex engines
+      text =
+        '''
+        /* Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas. */
+        '''
+
+      res =
+        '''
+        /* Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard
+           sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+           fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest
+           quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro
+           actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia
+           sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher
+           direct trade, tacos pickled fanny pack literally meh pinterest slow-carb.
+           Meditation microdosing distillery 8-bit humblebrag migas. */
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows pound comments ', ->
+      text =
+        '''
+        # Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        # Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha
+        # banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        # fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa
+        # leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually
+        # aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial
+        # letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade,
+        # tacos pickled fanny pack literally meh pinterest slow-carb. Meditation
+        # microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows - list items ', ->
+      text =
+        '''
+        - Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        - Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha
+          banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+          fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa
+          leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually
+          aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial
+          letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade,
+          tacos pickled fanny pack literally meh pinterest slow-carb. Meditation
+          microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows % comments ', ->
+      text =
+        '''
+        % Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        % Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha
+        % banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        % fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa
+        % leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually
+        % aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial
+        % letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade,
+        % tacos pickled fanny pack literally meh pinterest slow-carb. Meditation
+        % microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows ;; comments ', ->
+      text =
+        '''
+        ;; Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        ;; Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard
+        ;; sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        ;; fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest
+        ;; quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro
+        ;; actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia
+        ;; sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher
+        ;; direct trade, tacos pickled fanny pack literally meh pinterest slow-carb.
+        ;; Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows > ascii email inclusions ', ->
+      text =
+        '''
+        > Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        > Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha
+        > banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        > fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa
+        > leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually
+        > aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial
+        > letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade,
+        > tacos pickled fanny pack literally meh pinterest slow-carb. Meditation
+        > microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,7 +313,6 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
 
     it 'properly reflows // comments ', ->
-      # Because there're known problems with this character in major regex engines
       text =
         '''
         // Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
@@ -334,7 +333,6 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
     it 'properly reflows /* comments ', ->
-      # Because there're known problems with this character in major regex engines
       text =
         '''
         /* Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas. */


### PR DESCRIPTION
Changes to address issues #4, #36, #39, #43
- Fixed reflow of lists with '-' line prefix
  - Added test
- Fixed reflow of '/*' block comments
  - Added test
- Added support for reflow of '%' single line comments
  - Added test
- Added support for reflow of ';;' single line comments
  - Added test
- Added support for reflow of '>' ascii email inclusions
  - Added test
- Added test for '#' single line comments
- Added test for '//' single line comments
