### PR TITLE
Reflow should remove the tailing spaces except the last line

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -48,22 +48,26 @@ module.exports =
       tabLengthInSpaces = ''
 
     for block in paragraphBlocks
-
       # TODO: this could be more language specific. Use the actual comment char.
       linePrefix = block.match(/^\s*[\/#*-]*\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)
       blockLines = block.split('\n')
-
+      
       if linePrefix
         escapedLinePrefix = _.escapeRegExp(linePrefix)
         blockLines = blockLines.map (blockLine) ->
           blockLine.replace(///^#{escapedLinePrefix}///, '')
-
+      
       blockLines = blockLines.map (blockLine) ->
         blockLine.replace(/^\s+/, '')
-
+      if blockLines.length > 1
+        blockLastLine = blockLines.pop()
+        blockLines = blockLines.map (blockLine) ->
+          blockLine.replace(/\s+$/, '')
+        blockLines.push(blockLastLine)
+      
       lines = []
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -48,18 +48,19 @@ module.exports =
       tabLengthInSpaces = ''
 
     for block in paragraphBlocks
+
       # TODO: this could be more language specific. Use the actual comment char.
       linePrefix = block.match(/^\s*[\/#*-]*\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)
       blockLines = block.split('\n')
-      
+
       if linePrefix
         escapedLinePrefix = _.escapeRegExp(linePrefix)
         blockLines = blockLines.map (blockLine) ->
           blockLine.replace(///^#{escapedLinePrefix}///, '')
-      
+
       blockLines = blockLines.map (blockLine) ->
         blockLine.replace(/^\s+/, '')
       if blockLines.length > 1
@@ -67,7 +68,7 @@ module.exports =
         blockLines = blockLines.map (blockLine) ->
           blockLine.replace(/\s+$/, '')
         blockLines.push(blockLastLine)
-      
+
       lines = []
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,8 +313,8 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
     
     it 'removes trailing spaces except the last line', ->
-      text = 'If there are trailing spaces in a line, the reflow    \nshould remove them except the last line of the block.    '
+      text = 'If there are trailing spaces in a line, the reflow    \r\nshould remove them except the last line of the block.    '
       
-      res = 'If there are trailing spaces in a line, the reflow should remove\nthem except the last line of the block.    '
+      res = 'If there are trailing spaces in a line, the reflow should remove\r\nthem except the last line of the block.    '
       
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,8 +313,14 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
     
     it 'removes trailing spaces except the last line', ->
-      text = 'If there are trailing spaces in a line, the reflow    \r\nshould remove them except the last line of the block.    '
+      text = """
+      If there are trailing spaces in a line, the reflow    
+      should remove them except the last line of the block.    
+      """
       
-      res = 'If there are trailing spaces in a line, the reflow should remove\r\nthem except the last line of the block.    '
+      res = """
+      If there are trailing spaces in a line, the reflow should remove
+      them except the last line of the block.    
+      """
       
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,8 +313,14 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
     
     it 'removes trailing spaces except the last line', ->
-      text = "If there are trailing spaces in a line, the reflow    \nshould remove them except the last line of the block.    "
+      text = """
+      If there are trailing spaces in a line, the reflow\t
+      should remove them except the last line of the block.\t\t
+      """
       
-      res = "If there are trailing spaces in a line, the reflow should remove\nthem except the last line of the block.    "
+      res = """
+      If there are trailing spaces in a line, the reflow should remove
+      them except the last line of the block.\t\t
+      """
       
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -315,6 +315,9 @@ describe "Autoflow package", ->
     it 'removes trailing spaces except the last line', ->
       text = "If there are trailing spaces in a line, the reflow    \r\nshould remove them except the last line of the block."
 
-      res = "If there are trailing spaces in a line, the reflow should remove\r\nthem except the last line of the block."
+      res = '''
+        If there are trailing spaces in a line, the reflow should remove
+        them except the last line of the block.
+      '''
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,14 +313,8 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
     
     it 'removes trailing spaces except the last line', ->
-      text = '''
-      If there are trailing spaces in a line, the reflow    
-      should remove them except the last line of the block.    
-      '''
+      text = 'If there are trailing spaces in a line, the reflow    \nshould remove them except the last line of the block.    '
       
-      res = '''
-      If there are trailing spaces in a line, the reflow should remove
-      them except the last line of the block.    
-      '''
+      res = 'If there are trailing spaces in a line, the reflow should remove\nthem except the last line of the block.    '
       
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -311,7 +311,6 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
-      expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
 
     it 'removes trailing spaces except the last line', ->
       text = "If there are trailing spaces in a line, the reflow\t      \nshould remove them except the last line of the block.\t\t"

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -311,16 +311,10 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
-    
+
     it 'removes trailing spaces except the last line', ->
-      text = """
-      If there are trailing spaces in a line, the reflow\t
-      should remove them except the last line of the block.\t\t
-      """
-      
-      res = """
-      If there are trailing spaces in a line, the reflow should remove
-      them except the last line of the block.\t\t
-      """
-      
+      text = "If there are trailing spaces in a line, the reflow    \r\nshould remove them except the last line of the block."
+
+      res = "If there are trailing spaces in a line, the reflow should remove\r\nthem except the last line of the block."
+
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,11 +313,11 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
 
     it 'removes trailing spaces except the last line', ->
-      text = "If there are trailing spaces in a line, the reflow      \nshould remove them except the last line of the block."
+      text = "If there are trailing spaces in a line, the reflow\t      \nshould remove them except the last line of the block.\t\t"
       
       res = """
         If there are trailing spaces in a line, the reflow should remove them except the
-        last line of the block.
+        last line of the block.\t\t
       """
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,14 +313,11 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
 
     it 'removes trailing spaces except the last line', ->
-      text = """
-      If there are trailing spaces in a line, the reflow\r\r\r
-      should remove them except the last line of the block.
-      """
+      text = "If there are trailing spaces in a line, the reflow      \nshould remove them except the last line of the block."
 
       res = """
-        If there are trailing spaces in a line, the reflow should remove
-        them except the last line of the block.
+        If there are trailing spaces in a line, the reflow should remove them
+        except the last line of the block.
       """
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -311,10 +311,11 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
+      expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
 
     it 'removes trailing spaces except the last line', ->
       text = "If there are trailing spaces in a line, the reflow\t      \nshould remove them except the last line of the block.\t\t"
-      
+
       res = """
         If there are trailing spaces in a line, the reflow should remove them except the
         last line of the block.\t\t

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,11 +313,14 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
 
     it 'removes trailing spaces except the last line', ->
-      text = "If there are trailing spaces in a line, the reflow    \r\nshould remove them except the last line of the block."
+      text = """
+      If there are trailing spaces in a line, the reflow\r\r\r
+      should remove them except the last line of the block.
+      """
 
-      res = '''
+      res = """
         If there are trailing spaces in a line, the reflow should remove
         them except the last line of the block.
-      '''
+      """
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -314,10 +314,10 @@ describe "Autoflow package", ->
 
     it 'removes trailing spaces except the last line', ->
       text = "If there are trailing spaces in a line, the reflow      \nshould remove them except the last line of the block."
-
+      
       res = """
-        If there are trailing spaces in a line, the reflow should remove them
-        except the last line of the block.
+        If there are trailing spaces in a line, the reflow should remove them except the
+        last line of the block.
       """
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -313,14 +313,8 @@ describe "Autoflow package", ->
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
     
     it 'removes trailing spaces except the last line', ->
-      text = """
-      If there are trailing spaces in a line, the reflow    
-      should remove them except the last line of the block.    
-      """
+      text = "If there are trailing spaces in a line, the reflow    \nshould remove them except the last line of the block.    "
       
-      res = """
-      If there are trailing spaces in a line, the reflow should remove
-      them except the last line of the block.    
-      """
+      res = "If there are trailing spaces in a line, the reflow should remove\nthem except the last line of the block.    "
       
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -311,3 +311,16 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
+    
+    it 'removes trailing spaces except the last line', ->
+      text = '''
+      If there are trailing spaces in a line, the reflow    
+      should remove them except the last line of the block.    
+      '''
+      
+      res = '''
+      If there are trailing spaces in a line, the reflow should remove
+      them except the last line of the block.    
+      '''
+      
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res


### PR DESCRIPTION
Hi there, 

When I use the reflow feature, I also end up with two spaces between the ending word of a line and the starting word of next line. E.g., 

test\<space\>
test

will become

test\<space\>\<space\>test

This is very inconvenient to me. I really love this feature (I use this feature frequently in TextWrangler). So I expect that it can become

test\<space\>test

In addition, we should leave the spaces for the last line of this block. E.g., 

test\<space\>
test\<space\>\<space\>\<space\>

should become 

test\<space\>test\<space\>\<space\>\<space\>

So I made this change and hope it can be added to the package. 

Cheers,
Hengfeng Li