### PR TITLE
Reflow should remove trailing spaces except the last line

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -64,6 +64,12 @@ module.exports =
       blockLines = blockLines.map (blockLine) ->
         blockLine.replace(/^\s+/, '')
 
+      if blockLines.length > 1
+        blockLastLine = blockLines.pop()
+        blockLines = blockLines.map (blockLine) ->
+          blockLine.replace(/\s+$/, '')
+        blockLines.push(blockLastLine)
+
       lines = []
       currentLine = []
       currentLineLength = linePrefixTabExpanded.length

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -311,3 +311,13 @@ describe "Autoflow package", ->
       '''
 
       expect(autoflow.reflow(text, wrapColumn: 2)).toEqual res
+
+    it 'removes trailing spaces except the last line', ->
+      text = "If there are trailing spaces in a line, the reflow\t      \nshould remove them except the last line of the block.\t\t"
+
+      res = """
+        If there are trailing spaces in a line, the reflow should remove them except the
+        last line of the block.\t\t
+      """
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res


### PR DESCRIPTION
Hi there,

When I use the reflow feature, I also end up with two spaces between the ending word of a line and the starting word of next line. E.g.,

```
test<space>
test
```

will become

```
test<space><space>test
```

This is very inconvenient to me. I really love this feature (I use this feature frequently in TextWrangler). So I expect that it can become

```
test<space>test
```

In addition, we should leave the spaces for the last line of this block. E.g.,

```
test<space>
test<space><space><space>
```

should become

```
test<space>test<space><space><space>
```

So I made this change and hope it can be added to the package. 

Sorry for repeatedly trying because this is my first time to submit a pull request. 

Cheers,
Hengfeng Li
