### PR TITLE
Optional Avoid-Short-Lines Reflow Algorithm

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -8,6 +8,23 @@ CharacterPattern = ///
 ///
 
 module.exports =
+  config:
+    algorithm:
+      title: 'Reflow Algorithm'
+      description: '''
+      This determines how text is reflowed. The two options are to either just
+      [put as many words as possible on each
+      line](https://en.wikipedia.org/wiki/Line_wrap_and_word_wrap#Minimum_number_of_lines),
+      or to [try to avoid getting very short lines after
+      reflowing](https://en.wikipedia.org/wiki/Line_wrap_and_word_wrap#Minimum_raggedness).
+      '''
+      type: 'string'
+      default: 'greedy'
+      enum: [
+        {value: 'greedy', description: 'Put as many words as possible on each line'}
+        {value: 'minimumRaggedness', description: 'Avoid short lines after reflow'}
+      ]
+
   activate: ->
     atom.commands.add 'atom-text-editor',
       'autoflow:reflow-selection': (event) =>
@@ -21,10 +38,11 @@ module.exports =
     reflowOptions =
         wrapColumn: @getPreferredLineLength(editor)
         tabLength: @getTabLength(editor)
+        algorithm: @getAlgorithm(editor)
     reflowedText = @reflow(editor.getTextInRange(range), reflowOptions)
     editor.getBuffer().setTextInRange(range, reflowedText)
 
-  reflow: (text, {wrapColumn, tabLength}) ->
+  reflow: (text, {wrapColumn, tabLength, algorithm}) ->
     paragraphs = []
     # Convert all \r\n and \r to \n. The text buffer will normalize them later
     text = text.replace(/\r\n?/g, '\n')
@@ -46,6 +64,10 @@ module.exports =
       tabLengthInSpaces = Array(tabLength + 1).join(' ')
     else
       tabLengthInSpaces = ''
+
+    @reflowNonPrefixedLines = @greedyReflow
+    if algorithm is "minimumRaggedness"
+      @reflowNonPrefixedLines = @minimumRaggednessReflow
 
     for block in paragraphBlocks
 
@@ -73,7 +95,8 @@ module.exports =
 
     leadingVerticalSpace + paragraphs.join('\n\n') + trailingVerticalSpace
 
-  reflowNonPrefixedLines: (text, wrapColumn) ->
+  # Greedy reflow; just put as many words as possible on each line
+  greedyReflow: (text, wrapColumn) ->
     lines = []
     currentLine = []
     currentLineLength = 0
@@ -89,6 +112,73 @@ module.exports =
     lines.push(currentLine.join(''))
 
     return lines
+
+# Minimum raggedness algorithm ported from http://xxyxyz.org/line-breaking.
+  #
+  # This is the "Shortest path" one.
+  minimumRaggednessReflow: (text, wrapColumn) ->
+    VERY_MUCH = 10**6
+
+    words = text.split /[\s]+/
+    count = words.length
+    if count.length is 0
+      return []
+
+    offsets = [0]
+    for segment in words
+      offsets.push(offsets[offsets.length - 1] + segment.length)
+
+    minima = [0].concat(VERY_MUCH for [1..count])
+    breaks = (0 for [0..count])
+    for i in [0..(count - 1)]
+      j = i + 1
+      # "i" is the index of the first word of the current line
+      # "j" is the index of the last word of the current line
+
+      while j <= count
+        chars_i_to_j = offsets[j] - offsets[i]
+        spaces_i_to_j = j - i - 1
+        width_i_to_j = chars_i_to_j + spaces_i_to_j
+        if width_i_to_j > wrapColumn
+          if j is (i + 1)
+            # This is a single word that is longer than the allowed line length,
+            # just take as it is and pretend it was perfect.
+            #
+            # "Perfect" in this case means that no extra penalty is incurred by
+            # breaking here.
+            minima[j] = minima[i]
+            breaks[j] = i
+            j += 1
+
+          break
+
+        current_line_penalty = (wrapColumn - width_i_to_j) ** 2
+        if j is count
+          # We're on the last line, we don't care how short this one is.
+          #
+          # The reason this is the last line is that the last word of the
+          # current line (j) is the last word of the text (count).
+          current_line_penalty = 0
+
+        cost = minima[i] + current_line_penalty
+        if cost < minima[j]
+          minima[j] = cost
+          breaks[j] = i
+        j += 1
+
+    lines = []
+    j = count
+    while j > 0
+      i = breaks[j]
+      if (j > i)
+        lines.push(words[i..(j - 1)].join(' '))
+      j = i
+
+    lines.reverse()
+    return lines
+
+  getAlgorithm: (editor) ->
+    atom.config.get('autoflow.algorithm')
 
   getTabLength: (editor) ->
     atom.config.get('editor.tabLength', scope: editor.getRootScopeDescriptor()) ? 2

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -64,22 +64,31 @@ module.exports =
       blockLines = blockLines.map (blockLine) ->
         blockLine.replace(/^\s+/, '')
 
-      lines = []
-      currentLine = []
-      currentLineLength = linePrefixTabExpanded.length
-
-      for segment in @segmentText(blockLines.join(' '))
-        if @wrapSegment(segment, currentLineLength, wrapColumn)
-          lines.push(linePrefix + currentLine.join(''))
-          currentLine = []
-          currentLineLength = linePrefixTabExpanded.length
-        currentLine.push(segment)
-        currentLineLength += segment.length
-      lines.push(linePrefix + currentLine.join(''))
+      lines = @reflowNonPrefixedLines(blockLines.join(' '),
+                                      wrapColumn - linePrefixTabExpanded.length)
+      lines = lines.map (line) ->
+        linePrefix + line
 
       paragraphs.push(lines.join('\n').replace(/\s+\n/g, '\n'))
 
     leadingVerticalSpace + paragraphs.join('\n\n') + trailingVerticalSpace
+
+  reflowNonPrefixedLines: (text, wrapColumn) ->
+    lines = []
+    currentLine = []
+    currentLineLength = 0
+
+    for segment in @segmentText(text)
+      # A segment is basically a word or whitespace
+      if @wrapSegment(segment, currentLineLength, wrapColumn)
+        lines.push(currentLine.join(''))
+        currentLine = []
+        currentLineLength = 0
+      currentLine.push(segment)
+      currentLineLength += segment.length
+    lines.push(currentLine.join(''))
+
+    return lines
 
   getTabLength: (editor) ->
     atom.config.get('editor.tabLength', scope: editor.getRootScopeDescriptor()) ? 2


### PR DESCRIPTION
### Description of the Change

Give people a choice to not get very short lines after reflow by implementing [Minimum Raggedness](https://en.wikipedia.org/wiki/Line_wrap_and_word_wrap#Minimum_raggedness) reflow. Last line can be short, the short-line-avoidance is for all other lines.

Before this change, I frequently had to fix up the text after reflowing it.

With this change in place the reflow could be fully automatic for me, and I wouldn't have to manually fix up the reflow result.

Before this change, we greedily put as many words as possible on each line. That could have the following result. Note the very short second-to-last line:
![old-reflow](https://cloud.githubusercontent.com/assets/158201/24299921/f444b32e-10aa-11e7-96fd-dbd458faf541.png)

With this change in place, we optionally minimise the sum of the squares of the amount of whitespace at the end of each line. That gives us this result for the same text. Note no very short line at the second-to-last line:
![new-reflow](https://cloud.githubusercontent.com/assets/158201/24299981/2cfa0df4-10ab-11e7-8385-cd069c87338b.png)

And here's what the preferences page looks like with this patch applied:
![minimum-prefs](https://cloud.githubusercontent.com/assets/158201/24523519/8c034512-1593-11e7-8769-dd5b762a086d.png)

Code and inspiration comes from here, I've ported the "Shortest path" implementation:
http://xxyxyz.org/line-breaking

### Alternate Designs

This is the alternate design :)

### Benefits

No very short lines after invoking reflow. See screenshots.

### Possible Drawbacks

No obvious ones, but if I have to come up with something it would be that this has a non-linear complexity. In the (Python) benchmarks on the inspirational web page this algorithm reflows 25000 words at about 100 chars width in 0.1s, so I doubt this would be a problem.

### Applicable Issues

N/A