### PR TITLE
Extract reflow into its own function

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -64,22 +64,31 @@ module.exports =
       blockLines = blockLines.map (blockLine) ->
         blockLine.replace(/^\s+/, '')
 
-      lines = []
-      currentLine = []
-      currentLineLength = linePrefixTabExpanded.length
-
-      for segment in @segmentText(blockLines.join(' '))
-        if @wrapSegment(segment, currentLineLength, wrapColumn)
-          lines.push(linePrefix + currentLine.join(''))
-          currentLine = []
-          currentLineLength = linePrefixTabExpanded.length
-        currentLine.push(segment)
-        currentLineLength += segment.length
-      lines.push(linePrefix + currentLine.join(''))
+      lines = @reflowNonPrefixedLines(blockLines.join(' '),
+                                      wrapColumn - linePrefixTabExpanded.length)
+      lines = lines.map (line) ->
+        linePrefix + line
 
       paragraphs.push(lines.join('\n').replace(/\s+\n/g, '\n'))
 
     leadingVerticalSpace + paragraphs.join('\n\n') + trailingVerticalSpace
+
+  reflowNonPrefixedLines: (text, wrapColumn) ->
+    lines = []
+    currentLine = []
+    currentLineLength = 0
+
+    for segment in @segmentText(text)
+      # A segment is basically a word or whitespace
+      if @wrapSegment(segment, currentLineLength, wrapColumn)
+        lines.push(currentLine.join(''))
+        currentLine = []
+        currentLineLength = 0
+      currentLine.push(segment)
+      currentLineLength += segment.length
+    lines.push(currentLine.join(''))
+
+    return lines
 
   getTabLength: (editor) ->
     atom.config.get('editor.tabLength', scope: editor.getRootScopeDescriptor()) ? 2


### PR DESCRIPTION
The purpose of this change is to simplify maintaining a fork with an
alternative reflow algorithm as suggested here:
https://github.com/atom/autoflow/pull/59#issuecomment-299649957

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Extract the actual reflow code into its own function.


<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The alternative was PR #59, this is Plan B :).

### Benefits

<!-- What benefits will be realized by the code change? -->

For a fork that wants to provide multiple implementations of the reflow function, this change will make the fork diff smaller and easier to maintain.

For this repo, it will mostly make the `reflow()` function shorter.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Don't know.

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A