### PR TITLE
Support Idris-syle comments (|||)

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -50,7 +50,7 @@ module.exports =
     for block in paragraphBlocks
 
       # TODO: this could be more language specific. Use the actual comment char.
-      linePrefix = block.match(/^\s*[\/#*-]*\s*/g)[0]
+      linePrefix = block.match(/^\s*[\/#*-|]*\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -195,7 +195,7 @@ describe "Autoflow package", ->
       '''
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
-    it 'respects prefixed text (comments!)', ->
+    it 'respects prefixed text (sh/haskell/idris comments)', ->
       text = '''
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus gravida nibh id magna ullamcorper sagittis. Maecenas
         et enim eu orci tincidunt adipiscing
@@ -203,9 +203,12 @@ describe "Autoflow package", ->
 
           #  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
           #  Phasellus gravida
-          #  nibh id magna ullamcorper
-          #  tincidunt adipiscing lacinia a dui. Etiam quis erat dolor.
-          #  rutrum nisl fermentum  rhoncus. Duis blandit ligula facilisis fermentum
+
+          --  nibh id magna
+          --  ullamcorper
+
+          ||| tincidunt adipiscing lacinia a dui. Etiam quis erat dolor.
+          ||| rutrum nisl fermentum  rhoncus. Duis blandit ligula facilisis fermentum
       '''
 
       res = '''
@@ -214,9 +217,11 @@ describe "Autoflow package", ->
         aliquam ligula.
 
           #  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus gravida
-          #  nibh id magna ullamcorper tincidunt adipiscing lacinia a dui. Etiam quis
-          #  erat dolor. rutrum nisl fermentum  rhoncus. Duis blandit ligula facilisis
-          #  fermentum
+
+          -- nibh id magna ullamcorper
+
+          ||| tincidunt adipiscing lacinia a dui. Etiam quis erat dolor. rutrum nisl fermentum
+          ||| rhoncus. Duis blandit ligula facilisis fermentum
       '''
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 


### PR DESCRIPTION
Idiomatic Idris code:

```
||| Nodes in the AST can be of many types, determined by a list of Strings; the schema for this tree
||| structure, defined in NodeTypes, is used to type-check the tree.
data TypedAst : Type where
  Leaf    : (a : String) -> TypedAst
  NonLeaf : (a : String) -> Vect k TypedAst -> TypedAst
```

Without my changes, `apm test` produces:

```
Finished in 0.327 seconds
16 tests, 16 assertions, 11 failures, 0 skipped
```

... so I don't know if my new unittest is supposed to pass.