### PR TITLE
Fix linePrefix regex bugs

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -50,7 +50,8 @@ module.exports =
     for block in paragraphBlocks
 
       # TODO: this could be more language specific. Use the actual comment char.
-      linePrefix = block.match(/^\s*[\/#*%->(;;)(#')']*\s*/g)[0]
+      # Remember that `-` has to be the last character in the set
+      linePrefix = block.match(/^\s*([#%*>-]|\/\/|\/\*|;;)?\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -432,6 +432,26 @@ describe "Autoflow package", ->
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
+    it 'does not treat lines starting with a single semicolon as ;; comments', ->
+      text =
+        '''
+        ;! Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        ;! Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard
+        sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa
+        leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually
+        aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial
+        letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade,
+        tacos pickled fanny pack literally meh pinterest slow-carb. Meditation
+        microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
     it 'properly reflows > ascii email inclusions ', ->
       text =
         '''


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This PR fixes two bugs.  The first is that we were attempting to match `;;` in a character set, which is impossible since character classes look at single characters only.  There was a similar bug with `//` and `/*`.  To fix that, I've extracted multi-character prefixes out of the character class.  There were also some odd parentheses + quotes stuff going on in there that I've removed.  The second bug is that the `-` character is special inside character classes.  `[%->]` does not mean "`%` or `-` or `>`" but rather "characters between `%` and `>`, inclusive (indexes 37 to 62)".  The fix for that is simple - move the `-` to the end of the character class.

### Alternate Designs

None.

### Benefits

`#*%>##;%*/` should no longer be treated as a valid prefix.  Characters between 37 and 62 should no longer be treated as prefixes.  `;;`, `//`, and `/*` are now tested properly.

### Possible Drawbacks

None.

### Applicable Issues

Follow-up from #45