### PR TITLE
Support Idris and Haskell comments

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -54,8 +54,8 @@ module.exports =
     for block in paragraphBlocks
 
       # TODO: this could be more language specific. Use the actual comment char.
-      # Remember that `-` has to be the last character in the set
-      linePrefix = block.match(/^\s*([#%*>-]|\/\/|\/\*|;;|#'|\|\|\|)?\s*/g)[0]
+      # Remember that `-` has to be the last character in the character class.
+      linePrefix = block.match(/^\s*(\/\/|\/\*|;;|#'|\|\|\||--|[#%*>-])?\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)
@@ -75,7 +75,7 @@ module.exports =
 
       wrappedLinePrefix = linePrefix
         .replace(/^(\s*)\/\*/, '$1  ')
-        .replace(/^(\s*)-/, '$1 ')
+        .replace(/^(\s*)-(?!-)/, '$1 ')
 
       firstLine = true
       for segment in @segmentText(blockLines.join(' '))
@@ -84,7 +84,7 @@ module.exports =
           # Independent of line prefix don't mess with it on the first line
           if firstLine isnt true
             # Handle C comments
-            if linePrefix.search(/^\s*\/\*/) isnt -1 or linePrefix.search(/^\s*-/) isnt -1
+            if linePrefix.search(/^\s*\/\*/) isnt -1 or linePrefix.search(/^\s*-(?!-)/) isnt -1
               linePrefix = wrappedLinePrefix
           lines.push(linePrefix + currentLine.join(''))
           currentLine = []

--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -55,7 +55,7 @@ module.exports =
 
       # TODO: this could be more language specific. Use the actual comment char.
       # Remember that `-` has to be the last character in the set
-      linePrefix = block.match(/^\s*([#%*>-]|\/\/|\/\*|;;|#')?\s*/g)[0]
+      linePrefix = block.match(/^\s*([#%*>-]|\/\/|\/\*|;;|#'|\|\|\|)?\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -432,6 +432,26 @@ describe "Autoflow package", ->
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
+    it "properly reflows ||| comments ", ->
+      text =
+        '''
+        ||| Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        ||| Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard
+        ||| sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        ||| fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest
+        ||| quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro
+        ||| actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia
+        ||| sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher
+        ||| direct trade, tacos pickled fanny pack literally meh pinterest slow-carb.
+        ||| Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
     it 'properly reflows ;; comments ', ->
       text =
         '''

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -432,6 +432,26 @@ describe "Autoflow package", ->
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
+    it "properly reflows -- comments ", ->
+      text =
+        '''
+        -- Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      res =
+        '''
+        -- Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard
+        -- sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical
+        -- fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest
+        -- quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro
+        -- actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia
+        -- sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher
+        -- direct trade, tacos pickled fanny pack literally meh pinterest slow-carb.
+        -- Meditation microdosing distillery 8-bit humblebrag migas.
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
     it "properly reflows ||| comments ", ->
       text =
         '''

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -412,7 +412,7 @@ describe "Autoflow package", ->
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
 
-    it "properly reflows #' comments ", ->
+    it "properly reflows roxygen comments ", ->
       text =
         '''
         #' Beard pinterest actually brunch brooklyn jean shorts YOLO. Knausgaard sriracha banh mi, cold-pressed retro whatever ethical man braid asymmetrical fingerstache narwhal. Intelligentsia wolf photo booth, tumblr pinterest quinoa leggings four loko poutine. DIY tattooed drinking vinegar, wolf retro actually aesthetic austin keffiyeh marfa beard. Marfa trust fund salvia sartorial letterpress, keffiyeh plaid butcher. Swag try-hard dreamcatcher direct trade, tacos pickled fanny pack literally meh pinterest slow-carb. Meditation microdosing distillery 8-bit humblebrag migas.


### PR DESCRIPTION
`|||` and `--`.  Also unskips the roxygen test.  Character class was moved to the end so that the more-specific/longer matches get higher priority.

Supersedes and closes #63.