### PR TITLE
Don't let special characters surpass wrapColumn

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -2,8 +2,7 @@ _ = require 'underscore-plus'
 
 CharacterPattern = ///
   [
-    \w                                     # English
-    \u0410-\u042F\u0401\u0430-\u044F\u0451 # Cyrillic
+    ^\s
   ]
 ///
 

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -531,3 +531,32 @@ describe "Autoflow package", ->
         '''
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it "doesn't allow special characters to surpass wrapColumn", ->
+      test =
+        '''
+        Imagine that I'm writing some LaTeX code. I start a comment, but change my mind. %
+
+        Now I'm just kind of trucking along, doing some math and stuff. For instance, $3 + 4 = 7$. But maybe I'm getting really crazy and I use subtraction. It's kind of an obscure technique, but often it goes a bit like this: let $x = 2 + 2$, so $x - 1 = 3$ (quick maths).
+
+        That's OK I guess, but now look at this cool thing called set theory: $\\{n + 42 : n \\in \\mathbb{N}\\}$. Wow. Neat. But we all know why we're really here. If you peer deep down into your heart, and you stare into the depths of yourself: is $P = NP$? Beware, though; many have tried and failed to answer this question. It is by no means for the faint of heart.
+        '''
+
+      res =
+        '''
+        Imagine that I'm writing some LaTeX code. I start a comment, but change my mind.
+        %
+
+        Now I'm just kind of trucking along, doing some math and stuff. For instance, $3
+        + 4 = 7$. But maybe I'm getting really crazy and I use subtraction. It's kind of
+        an obscure technique, but often it goes a bit like this: let $x = 2 + 2$, so $x
+        - 1 = 3$ (quick maths).
+
+        That's OK I guess, but now look at this cool thing called set theory: $\\{n + 42
+        : n \\in \\mathbb{N}\\}$. Wow. Neat. But we all know why we're really here. If you
+        peer deep down into your heart, and you stare into the depths of yourself: is $P
+        = NP$? Beware, though; many have tried and failed to answer this question. It is
+        by no means for the faint of heart.
+        '''
+
+      expect(autoflow.reflow(test, wrapColumn: 80)).toEqual res


### PR DESCRIPTION
### Description of the Change

Before this change, if a special character occurred as its own word past the end of a line, it would not be wrapped. This change causes all groups of non-whitespace characters to be treated the same (in keeping with the rest of the implementation), so nothing is allowed to exist past the specified `wrapColumn` unless it is simply too long to be wrapped.

### Alternate Designs

Given that the [`segmentText` regex][re] uses `^\s`, this seems like the only reasonable solution.

### Benefits

Editing LaTeX code is less annoying (see the included test).

### Possible Drawbacks

None that I'm aware of.

### Applicable Issues

None that I'm aware of.

[re]: https://github.com/atom/autoflow/blob/v0.29.3/lib/autoflow.coffee#L114