### PR TITLE
Handles wrapping text around LaTeX tags

### DIFF
--- a/lib/autoflow.coffee
+++ b/lib/autoflow.coffee
@@ -52,14 +52,30 @@ module.exports =
       tabLengthInSpaces = ''
 
     for block in paragraphBlocks
+      blockLines = block.split('\n')
+
+      # For LaTeX tags surrounding the text, we simply ignore them, and
+      # reproduce them verbatim in the wrapped text.
+      beginningLinesToIgnore = []
+      endingLinesToIgnore = []
+      latexTagRegex = /^\s*\\\w+(\[.*\])?\{\w+\}(\[.*\])?\s*$/g    # e.g. \begin{verbatim}
+      latexTagStartRegex = /^\s*\\\w+\s*\{\s*$/g                   # e.g. \item{
+      latexTagEndRegex = /^\s*\}\s*$/g                             # e.g. }
+      while blockLines[0].match(latexTagRegex) or
+            blockLines[0].match(latexTagStartRegex)
+        beginningLinesToIgnore.push(blockLines[0])
+        blockLines.shift()
+      while blockLines[blockLines.length - 1].match(latexTagRegex) or
+            blockLines[blockLines.length - 1].match(latexTagEndRegex)
+        endingLinesToIgnore.unshift(blockLines[blockLines.length - 1])
+        blockLines.pop()
 
       # TODO: this could be more language specific. Use the actual comment char.
       # Remember that `-` has to be the last character in the character class.
-      linePrefix = block.match(/^\s*(\/\/|\/\*|;;|#'|\|\|\||--|[#%*>-])?\s*/g)[0]
+      linePrefix = blockLines[0].match(/^\s*(\/\/|\/\*|;;|#'|\|\|\||--|[#%*>-])?\s*/g)[0]
       linePrefixTabExpanded = linePrefix
       if tabLengthInSpaces
         linePrefixTabExpanded = linePrefix.replace(/\t/g, tabLengthInSpaces)
-      blockLines = block.split('\n')
 
       if linePrefix
         escapedLinePrefix = _.escapeRegExp(linePrefix)
@@ -94,7 +110,8 @@ module.exports =
         currentLineLength += segment.length
       lines.push(linePrefix + currentLine.join(''))
 
-      paragraphs.push(lines.join('\n').replace(/\s+\n/g, '\n'))
+      wrappedLines = beginningLinesToIgnore.concat(lines.concat(endingLinesToIgnore))
+      paragraphs.push(wrappedLines.join('\n').replace(/\s+\n/g, '\n'))
 
     leadingVerticalSpace + paragraphs.join('\n\n') + trailingVerticalSpace
 

--- a/spec/autoflow-spec.coffee
+++ b/spec/autoflow-spec.coffee
@@ -531,3 +531,70 @@ describe "Autoflow package", ->
         '''
 
       expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows text around LaTeX tags', ->
+      text =
+        '''
+        \\begin{verbatim}
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
+        \\end{verbatim}
+        '''
+
+      res =
+        '''
+        \\begin{verbatim}
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
+            blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget
+            condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec
+            semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit
+            quam, elementum neque pellentesque pulvinar et vestibulum.
+        \\end{verbatim}
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows text inside LaTeX tags', ->
+      text =
+        '''
+        \\item{
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
+        }
+        '''
+
+      res =
+        '''
+        \\item{
+            Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
+            blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget
+            condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec
+            semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit
+            quam, elementum neque pellentesque pulvinar et vestibulum.
+        }
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res
+
+    it 'properly reflows text inside nested LaTeX tags', ->
+      text =
+        '''
+        \\begin{enumerate}[label=(\\alph*)]
+            \\item{
+                Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
+            }
+        \\end{enumerate}
+        '''
+
+      res =
+        '''
+        \\begin{enumerate}[label=(\\alph*)]
+            \\item{
+                Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
+                blandit, vel vestibulum libero dolor, semper lobortis ligula praesent.
+                Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue.
+                Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore
+                velit quam, elementum neque pellentesque pulvinar et vestibulum.
+            }
+        \\end{enumerate}
+        '''
+
+      expect(autoflow.reflow(text, wrapColumn: 80)).toEqual res


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Currently, LaTeX tags that are placed next to the text would be wrapped together with the text. For example, the following text: 

```latex
\begin{enumerate}[label=(\alph*)]
    \item{
        Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum.
    }
\end{enumerate}
```

would be wrapped to

```latex
\begin{enumerate}[label=(\alph*)] \item{ Lorem ipsum dolor sit amet, nisl odio
amet, et tempor netus neque at at blandit, vel vestibulum libero dolor, semper
lobortis ligula praesent. Eget condimentum integer, porta sagittis nam, fusce
vitae a vitae augue. Nec semper quis sed ut, est porttitor praesent. Nisl velit
quam dolore velit quam, elementum neque pellentesque pulvinar et vestibulum. }
\end{enumerate}
```

whereas the expected result is

```latex
\begin{enumerate}[label=(\alph*)]
    \item{
        Lorem ipsum dolor sit amet, nisl odio amet, et tempor netus neque at at
        blandit, vel vestibulum libero dolor, semper lobortis ligula praesent.
        Eget condimentum integer, porta sagittis nam, fusce vitae a vitae augue.
        Nec semper quis sed ut, est porttitor praesent. Nisl velit quam dolore
        velit quam, elementum neque pellentesque pulvinar et vestibulum.
    }
\end{enumerate}
```

This PR changes the wrapping algorithm such that lines at the beginning and end of each paragraph that resemble LaTeX tags would be ignored for the purpose of wrapping. At the end of the wrapping process, they would be reproduced verbatim. This results in the expected result shown above.

This PR adds 3 test cases in `spec/autoflow-spec.coffee` that demonstrate and test the expected behavior.

### Alternate Designs

N/A

### Benefits

This would hopefully make `autoflow` more useful in a LaTeX workflow :)

### Possible Drawbacks

The main drawback is the potential of non-LaTeX-tags being mis-detected as LaTeX tags, and therefore ignored from the wrapping process. To minimize this risk, the matching regular expressions are written to match the whole line using `/^...$/g` instead of any part of the line.

### Applicable Issues

#18 