### PR TITLE
Update README.md to mention repo deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+### This package is now a part of the [core Atom repository](https://github.com/atom/atom/tree/master/packages/autoflow), please direct all issues and pull requests there in the future!
+
+---
+
 # Autoflow package
 [![OS X Build Status](https://travis-ci.org/atom/autoflow.svg?branch=master)](https://travis-ci.org/atom/autoflow) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/kpmsnkbooa29x907/branch/master?svg=true)](https://ci.appveyor.com/project/Atom/autoflow/branch/master) [![Dependency Status](https://david-dm.org/atom/autoflow.svg)](https://david-dm.org/atom/autoflow)
 


### PR DESCRIPTION
As of atom/atom#18014, the `autoflow` package is now a part of the core Atom repository. This pull request updates README.md to reflect that fact. We'll be archiving this repository shortly.

/cc https://github.com/atom/atom/issues/17833